### PR TITLE
Update links and image paths in PCB module documentation to use versioned references

### DIFF
--- a/docs/avionics/PCB-Modules/backplate.md
+++ b/docs/avionics/PCB-Modules/backplate.md
@@ -1,6 +1,6 @@
 # Backplate
 
-[v0.1.0-alpha](https://github.com/sonicavionics/4in-backplate/tree/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14)
+[v0.1.0-alpha](https://github.com/sonicavionics/4in-backplate/tree/v0.1.0-alpha)
 
 ---
 
@@ -9,17 +9,17 @@ The backplate is extremely simple. It has 140 through hole pins and two SMD whic
 ---
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14/images/board.front.png" alt="3D Render">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14/images/board.back.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/v0.1.0-alpha/images/board.front.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/v0.1.0-alpha/images/board.back.png" alt="3D Render">
 </div>
 <p class="image-caption">3D Render</p>
 
-![alt text](https://raw.githubusercontent.com/sonicavionics/4in-backplate/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14/images/sch.svg)
+![alt text](https://raw.githubusercontent.com/sonicavionics/4in-backplate/v0.1.0-alpha/images/sch.svg)
 <p class="image-caption">Schematic</p>
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14/images/pcbf.svg" alt="Front">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/d4f4168a124c0bf8ad42ad3644d11e950f6cbc14/images/pcbb.svg" alt="Back">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/v0.1.0-alpha/images/pcbf.svg" alt="Front">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/v0.1.0-alpha/images/pcbb.svg" alt="Back">
 </div>
 <p class="image-caption">Footprint</p>
 

--- a/docs/avionics/PCB-Modules/powersim.md
+++ b/docs/avionics/PCB-Modules/powersim.md
@@ -1,6 +1,6 @@
 # PowerSim
 
-[v0.2.0-alpha](https://github.com/sonicavionics/4in-powersim/tree/87c5420f04c32dd049ac773f05f2169482eee1a7)
+[v0.2.0-alpha](https://github.com/sonicavionics/4in-powersim/tree/v0.2.0-alpha)
 
 ---
 
@@ -9,17 +9,17 @@ The PowerSim module is a precursor to the Power module. It's meant to be very si
 ---
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/87c5420f04c32dd049ac773f05f2169482eee1a7/images/board.front.png" alt="3D Render">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/87c5420f04c32dd049ac773f05f2169482eee1a7/images/board.back.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/v0.2.0-alpha/images/board.front.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/v0.2.0-alpha/images/board.back.png" alt="3D Render">
 </div>
 <p class="image-caption">3D Render</p>
 
-![alt text](https://raw.githubusercontent.com/sonicavionics/4in-powersim/87c5420f04c32dd049ac773f05f2169482eee1a7/images/sch.svg)
+![alt text](https://raw.githubusercontent.com/sonicavionics/4in-powersim/v0.2.0-alpha/images/sch.svg)
 <p class="image-caption">Schematic</p>
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/87c5420f04c32dd049ac773f05f2169482eee1a7/images/pcbf.svg" alt="Front">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/87c5420f04c32dd049ac773f05f2169482eee1a7/images/pcbb.svg" alt="Back">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/v0.2.0-alpha/images/pcbf.svg" alt="Front">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/v0.2.0-alpha/images/pcbb.svg" alt="Back">
 </div>
 <p class="image-caption">Footprint</p>
 

--- a/docs/avionics/PCB-Modules/sensors.md
+++ b/docs/avionics/PCB-Modules/sensors.md
@@ -1,6 +1,6 @@
 # Sensors
 
-[v0.2.0-alpha](https://github.com/sonicavionics/4in-sensors/tree/fa8dba4cfa3cd17b1c69879c97f85c59ab75e3bc)
+[v0.2.0-alpha](https://github.com/sonicavionics/4in-sensors/tree/v0.2.0-alpha)
 
 ---
 
@@ -10,8 +10,8 @@ The sensors module is responsible for logging and transmitting telemetry data. I
 ---
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/refs/heads/main/images/board.front.png" alt="3D Render">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/refs/heads/main/images/board.back.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/v0.2.0-alpha/images/board.front.png" alt="3D Render">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/v0.2.0-alpha/images/board.back.png" alt="3D Render">
 </div>
 <p class="image-caption">3D Render</p>
 
@@ -20,8 +20,8 @@ The sensors module is responsible for logging and transmitting telemetry data. I
 
 
 <div class="image-row">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/refs/heads/main/images/pcbf.svg" alt="Front">
-    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/refs/heads/main/images/pcbb.svg" alt="Back">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/v0.2.0-alpha/images/pcbf.svg" alt="Front">
+    <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/v0.2.0-alpha/images/pcbb.svg" alt="Back">
 </div>
 <p class="image-caption">Footprint</p>
 


### PR DESCRIPTION
This pull request includes updates to the documentation for various PCB modules. The main changes involve updating the version references and image URLs to point to the correct versions.

### Version reference updates:

* [`docs/avionics/PCB-Modules/backplate.md`](diffhunk://#diff-9fd08051aea09d389a631205a25eaa795c8208046c377edf52c3c3054e9c9357L3-R3): Updated version reference from `d4f4168a124c0bf8ad42ad3644d11e950f6cbc14` to `v0.1.0-alpha` and modified image URLs accordingly. [[1]](diffhunk://#diff-9fd08051aea09d389a631205a25eaa795c8208046c377edf52c3c3054e9c9357L3-R3) [[2]](diffhunk://#diff-9fd08051aea09d389a631205a25eaa795c8208046c377edf52c3c3054e9c9357L12-R22)
* [`docs/avionics/PCB-Modules/powersim.md`](diffhunk://#diff-35cd64aa25b6d949a4d89d942b16d5135c3c7ec9cdd18b235d7e0d07eb1f1472L3-R3): Updated version reference from `87c5420f04c32dd049ac773f05f2169482eee1a7` to `v0.2.0-alpha` and modified image URLs accordingly. [[1]](diffhunk://#diff-35cd64aa25b6d949a4d89d942b16d5135c3c7ec9cdd18b235d7e0d07eb1f1472L3-R3) [[2]](diffhunk://#diff-35cd64aa25b6d949a4d89d942b16d5135c3c7ec9cdd18b235d7e0d07eb1f1472L12-R22)
* [`docs/avionics/PCB-Modules/sensors.md`](diffhunk://#diff-2df194dd3432683f57e893a7ea7f8e3dd5aebebf71cefd9dfc053b2e4c253d9fL3-R3): Updated version reference from `fa8dba4cfa3cd17b1c69879c97f85c59ab75e3bc` to `v0.2.0-alpha` and modified image URLs accordingly. [[1]](diffhunk://#diff-2df194dd3432683f57e893a7ea7f8e3dd5aebebf71cefd9dfc053b2e4c253d9fL3-R3) [[2]](diffhunk://#diff-2df194dd3432683f57e893a7ea7f8e3dd5aebebf71cefd9dfc053b2e4c253d9fL13-R14) [[3]](diffhunk://#diff-2df194dd3432683f57e893a7ea7f8e3dd5aebebf71cefd9dfc053b2e4c253d9fL23-R24)