### PR TITLE
Remove target="_blank" from module links in avionics documentation

### DIFF
--- a/docs/avionics/index.md
+++ b/docs/avionics/index.md
@@ -19,23 +19,23 @@ table, table * {
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-sensors/refs/heads/main/images/board.front.png" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/sensors/" target="_blank"><i>Sensors</i></a>
+        <a href="PCB-Modules/sensors/"><i>Sensors</i></a>
       </td>
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-power/refs/heads/main/images/board.front.png" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/power/" target="_blank"><i>Power</i></a>
+        <a href="PCB-Modules/power/"><i>Power</i></a>
       </td>
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-powersim/refs/heads/main/images/board.front.png" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/powersim/" target="_blank"><i>PowerSim</i></a>
+        <a href="PCB-Modules/powersim/"><i>PowerSim</i></a>
       </td>
       <!-- Extra column cell with rowspan -->
       <td rowspan="2" align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-backplate/refs/heads/main/images/board.front.png" alt="Longer Image" style="height:auto; width:150px;" />
         <br />
-        <a href="PCB-Modules/backplate/" target="_blank"><i>Backplate</i></a>
+        <a href="PCB-Modules/backplate/"><i>Backplate</i></a>
       </td>
     </tr>
     <!-- Second Row -->
@@ -43,17 +43,17 @@ table, table * {
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-gps/refs/heads/main/images/board.front.png" alt="GPS" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/gps/" target="_blank"><i>GPS</i></a>
+        <a href="PCB-Modules/gps/"><i>GPS</i></a>
       </td>
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-recovery/refs/heads/main/images/board.front.png" alt="Recovery" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/recovery/" target="_blank"><i>Recovery</i></a>
+        <a href="PCB-Modules/recovery/"><i>Recovery</i></a>
       </td>
       <td align="center" style="vertical-align: middle;">
         <img src="https://raw.githubusercontent.com/sonicavionics/4in-antenna/refs/heads/main/images/board.front.png" alt="Antenna" style="height:auto; width:300px;" />
         <br />
-        <a href="PCB-Modules/antenna/" target="_blank"><i>Antenna</i></a>
+        <a href="PCB-Modules/antenna/"><i>Antenna</i></a>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Eliminate the use of `target="_blank"` in module links to enhance security and maintain consistency in the avionics documentation.