### PR TITLE
Update avionics documentation images and disable model viewer script

### DIFF
--- a/docs/avionics/index.md
+++ b/docs/avionics/index.md
@@ -59,7 +59,7 @@ table, table * {
   </table>
 </div>
 
-![alt text](cad/thumbnail.png)
+![alt text](https://raw.githubusercontent.com/sonicavionics/4in-avionics/refs/heads/main/exports/images/avionics_rack.PNG)
 <p class="image-caption">CAD</p>
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ hide:
 
 </div>
 
-<script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js"></script>
+<!-- <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js"></script> -->
 
 <!-- <figure markdown="span">
 
@@ -63,7 +63,7 @@ table, table * {
       <a href="/avionics/PCB-Modules/sensors/">Sensor Module 0.2.0</a>
     </td>
       <td align="center" style="vertical-align: middle;">
-      <img src="/avionics/cad/thumbnail.png" width="250" /><br>
+      <img src="https://raw.githubusercontent.com/sonicavionics/4in-avionics/refs/heads/main/exports/images/avionics_rack.PNG" width="250" /><br>
       <a href="avionics/cad/">Avionics CAD</a>
     </td>
       <td align="center" style="vertical-align: middle;">


### PR DESCRIPTION
Replace outdated image links in the avionics documentation with updated URLs and comment out the model viewer script to prevent it from loading.