### PR TITLE
Fix category label from 'Order' to 'Purchases' in blog posts

### DIFF
--- a/docs/blog/posts/2025/april/7/7.md
+++ b/docs/blog/posts/2025/april/7/7.md
@@ -1,12 +1,12 @@
 ---
 title: April 7th Order
-date: 2025-04--7
+date: 2025-04-07
 comments: true
 authors:
   - zeul
 categories:
   - 4" Avionics
-  - Order
+  - Purchases
 ---
 
 Another round of antenna module tests:

--- a/docs/blog/posts/2025/february/16/16.md
+++ b/docs/blog/posts/2025/february/16/16.md
@@ -6,7 +6,7 @@ authors:
   - zeul
 categories:
   - 4" Avionics
-  - Order
+  - Purchases
 ---
 
 Two orders were made today/

--- a/docs/blog/posts/2025/january/17/17.md
+++ b/docs/blog/posts/2025/january/17/17.md
@@ -6,7 +6,7 @@ authors:
   - zeul
 categories:
   - 4" Avionics
-  - Order
+  - Purchases
 ---
 
 Ordered PowerSim and Sensors 0.2.0. 

--- a/docs/blog/posts/2025/january/25.md
+++ b/docs/blog/posts/2025/january/25.md
@@ -6,7 +6,7 @@ authors:
   - zeul
 categories:
   - 4" Avionics
-  - Order
+  - Purchases
 ---
 
 Ordered prototype antenna modules today. No assembly, just the PCBs for sizing.

--- a/docs/blog/posts/2025/january/3/3.md
+++ b/docs/blog/posts/2025/january/3/3.md
@@ -6,7 +6,7 @@ authors:
   - zeul
 categories:
   - 4" Avionics
-  - Order
+  - Purchases
 ---
 
 3 PCBs have been ordered today. Total was C$278.84. 


### PR DESCRIPTION
Update multiple blog posts to reflect the correct category label for better clarity and accuracy.